### PR TITLE
Forward model argument to  add_fit_to_inference_data in find_MAP

### DIFF
--- a/pymc_extras/inference/laplace_approx/find_map.py
+++ b/pymc_extras/inference/laplace_approx/find_map.py
@@ -335,13 +335,20 @@ def find_MAP(
         var.name: value for var, value in zip(unobserved_vars, unobserved_vars_values)
     }
 
-    idata = map_results_to_inference_data(optimized_point, frozen_model, include_transformed)
-    idata = add_fit_to_inference_data(idata, raveled_optimized, H_inv)
-    idata = add_optimizer_result_to_inference_data(
-        idata, optimizer_result, method, raveled_optimized, model
+    idata = map_results_to_inference_data(
+        map_point=optimized_point, model=frozen_model, include_transformed=include_transformed
     )
+
+    idata = add_fit_to_inference_data(
+        idata=idata, mu=raveled_optimized, H_inv=H_inv, model=frozen_model
+    )
+
+    idata = add_optimizer_result_to_inference_data(
+        idata=idata, result=optimizer_result, method=method, mu=raveled_optimized, model=model
+    )
+
     idata = add_data_to_inference_data(
-        idata, progressbar=False, model=model, compile_kwargs=compile_kwargs
+        idata=idata, progressbar=False, model=model, compile_kwargs=compile_kwargs
     )
 
     return idata

--- a/tests/inference/laplace_approx/test_find_map.py
+++ b/tests/inference/laplace_approx/test_find_map.py
@@ -185,6 +185,22 @@ def test_find_MAP(
         assert not hasattr(idata, "unconstrained_posterior")
 
 
+def test_find_map_outside_model_context():
+    """
+    Test that find_MAP can be called outside of a model context.
+    """
+    with pm.Model() as m:
+        mu = pm.Normal("mu", 0, 1)
+        sigma = pm.Exponential("sigma", 1)
+        y_hat = pm.Normal("y_hat", mu=mu, sigma=sigma, observed=np.random.normal(size=10))
+
+    idata = find_MAP(model=m, method="L-BFGS-B", use_grad=True, progressbar=False)
+
+    assert hasattr(idata, "posterior")
+    assert hasattr(idata, "fit")
+    assert hasattr(idata, "optimizer_result")
+
+
 @pytest.mark.parametrize(
     "backend, gradient_backend",
     [("jax", "jax")],


### PR DESCRIPTION
Bugfix for find_MAP. The following code currently errors:

```python
    with pm.Model() as m:
        mu = pm.Normal("mu", 0, 1)
        sigma = pm.Exponential("sigma", 1)
        y_hat = pm.Normal("y_hat", mu=mu, sigma=sigma, observed=np.random.normal(size=10))

    idata = find_MAP(
        model=m,
        method="L-BFGS-B",
        use_grad=True,
        use_hess=False,
        use_hessp=False,
        progressbar=False,
        compile_kwargs={"mode": "JAX"},
    )
```

Because the `model` argument is not correctly forwarded everywhere it is needed inside `find_MAP`. This patches the bug and adds a regression test. 